### PR TITLE
Fixed casing of the paths in the UsingTask

### DIFF
--- a/ShowMeTheXAML.MSBuild/Uno.ShowMeTheXAML.MSBuild.targets
+++ b/ShowMeTheXAML.MSBuild/Uno.ShowMeTheXAML.MSBuild.targets
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <UsingTask TaskName="ShowMeTheXAML.MSBuild.BuildXamlDictionaryTask"
-             AssemblyFile="$(MSBuildThisFileDirectory)/../../Tools/Uno.ShowMeTheXaml.MSBuild.dll" />
+             AssemblyFile="$(MSBuildThisFileDirectory)/../../tools/Uno.ShowMeTheXaml.MSBuild.dll" />
 
   <Target Name="BuildXamlDictionary" BeforeTargets="BeforeCompile">
     <BuildXamlDictionaryTask


### PR DESCRIPTION
Casing is important on Linux, and WASM is currently built on this platform, making this very important.