### PR TITLE
feat: Allow explicit XamlDictionary initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,23 @@ A WPF component making it easy to show the corresponding XAML for WPF custom sty
 ```C#
 protected override void OnStartup(StartupEventArgs e)
 {
-    XamlDisplay.Init();
+    XamlDisplay.Init(
+        // optional list of assemblies to look for ShowMeTheXAML data from.
+        // Automatically tries to load data from Assembly.GetEntryAssembly()
+    );
     base.OnStartup(e);
 }
 ```
+`XamlDisplay.Init()` does not work under Native AOT. For Native AOT support, invoke `XamlDictionary.Init()` from your `App.xaml.cs`:
+```C#
+protected override void OnStartup(StartupEventArgs e)
+{
+    XamlDictionary.Init();
+    base.OnStartup(e);
+}
+```
+*Note*: the difference between `XamlDisplay.Init()` and `XamlDictionary.Init()` is that `XamlDictionary.Init()` will look for `XamlDictionary` from `Assembly.GetEntryAssembly()` and from the list of `Assembly` instances provided to `XamlDisplay.Init()`. `XamlDictionary.Init()` does *not*.  As such, if multiple assemblies contain `XamlDictionary` types, new public APIs will need to be added to each such assembly and explicitly invoked in order for the `XamlDictionary` data to be used.
+
 3. (Optional) The default template is pretty basic. For a better looking style add the ShowMeTheXAML.AvalonEdit package. `PM> Install-Package ShowMeTheXAML.AvalonEdit`
 In App.xaml include the resource dictionary.
 ```XAML

--- a/ShowMeTheXAML.MSBuild/BuildXamlDictionaryTask.cs
+++ b/ShowMeTheXAML.MSBuild/BuildXamlDictionaryTask.cs
@@ -203,11 +203,16 @@ using System.Collections.Generic;
 
 namespace ShowMeTheXAML
 {{
-    public static class XamlDictionary
+    public static partial class XamlDictionary
     {{
         static XamlDictionary()
         {{
             {string.Join(Environment.NewLine, pairs.Select(p => $"XamlResolver.Set(\"{p.Key}\", @\"{p.Data}\");"))}
+        }}
+
+        public static void Init()
+        {{
+            // Do nothing; exists to allow explicit invocation of the static constructor
         }}
     }}
 }}");


### PR DESCRIPTION
Context: https://github.com/unoplatform/Uno.Gallery/pull/1233
Context: https://github.com/unoplatform/uno-private/issues/1696#issuecomment-3813491375

What do we want? To build and run Uno.Gallery with NativeAOT! (See also: unoplatform/Uno.Gallery#1233)

We also want Uno.Gallery to run *properly*.

The problem: The "`<>` Show XAML" button doesn't work properly.

Use unoplatform/Uno.Gallery#1233 to build and run Uno.Gallery with NativeAOT:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SelfContained=true \
	  -p:SkiaPublishAot=true
	./Uno.Gallery/bin/Release/net10.0-desktop/osx-x64/publish/Uno.Gallery

Once the app has launched, select **UI components > AutoSuggestBox** in the left-hand tree.  Then, in the right-hand panel, click the "`<>` Show XAML" button.

Expected results: *Something is shown*.

Actual results: An empty box is shown.

As with most NativeAOT-related issues, this is due to Reflection: `XamlDisplay.Init()` tries to lookup the `ShowMeTheXAML.XamlDictionary` type from an `Assembly`.  By default, nothing is statically referencing `XamlDictionary`, so it isn't accessible via Reflection, so this attempted lookup (silently) fails.

This aspect can be worked around in Uno.Gallery via [`[DynamicDependency]`][0], e.g.

	diff --git a/Uno.Gallery/App.xaml.cs b/Uno.Gallery/App.xaml.cs
	index 51ae161a..45b16dfd 100644
	--- a/Uno.Gallery/App.xaml.cs
	+++ b/Uno.Gallery/App.xaml.cs
	@@ -78,6 +78,7 @@ namespace Uno.Gallery
	                        }
	                }

	+               [System.Diagnostics.CodeAnalysis.DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ShowMeTheXAML.XamlDictionary))]
	                private void OnLaunchedOrActivated()
	                {
	                        MainWindow = new Window();

The problem is that once `XamlDisplay.Init()` finds `XamlDictionary`, it then attempts to invoke its static constructor:

	//Invoke the static constructor
	global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(xamlDictionary.TypeHandle);

*This* fails, hard:

	System.NotSupportedException: 'ShowMeTheXAML.XamlDictionary' is missing native code or metadata. This can happen for code that is not compatible with trimming or AOT. Inspect and fix trimming and AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
	   at System.Reflection.Runtime.TypeInfos.RuntimeTypeInfo.get_TypeHandle() + 0x95
	   at ShowMeTheXAML.XamlDisplay.<Init>g__LoadFromAssembly|7_0(Assembly) + 0x4d
	   at ShowMeTheXAML.XamlDisplay.Init(Assembly[]) + 0x47
	   at Uno.Gallery.App..ctor() + 0x99
	   at Uno.Gallery.Program.<>c.<Main>b__0_0() + 0x18
	   at Uno.UI.Runtime.Skia.MacOS.MacSkiaHost.<StartApp>g__CreateApp|18_0(ApplicationInitializationCallbackParams _) + 0x21
	   at Microsoft.UI.Xaml.Application.StartPartial(ApplicationInitializationCallback) + 0x70
	   at Uno.UI.Runtime.Skia.MacOS.MacSkiaHost.StartApp() + 0xbc

Address this by removing the *need* for Reflection: update the `XamlDictionary` templates to contain a static `Init()` method:

	partial class XamlDictionary
	{
	    public static void Init()
	    {
	    }
	}

This allows Uno.Gallery to *explicitly* call `XamlDictionary.Init()`, which *implicitly* invokes the `XamlDictionary` static constructor, avoiding the need for Reflection *entirely*.

This in turn allows the "`<>` Show XAML" button to work properly.

Additionally, make the `XamlDictionary` declaration `partial`, so that if future "workarounds" such as `Init()` are needed, a new `Uno.ShowMeTheXAML.MSBuild` NuGet package isn't required.

[0]: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.dynamicdependencyattribute?view=net-9.0

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->